### PR TITLE
Fix memory address range mismatch in VexRiscv Stage1 tests

### DIFF
--- a/sim/tests/vexriscv_dbus_access_test.sv
+++ b/sim/tests/vexriscv_dbus_access_test.sv
@@ -58,16 +58,16 @@ class vexriscv_dbus_access_test extends vexriscv_base_test;
         
         reset_cpu();
         
-        // Load test program with various store/load operations
-        write_memory_backdoor(32'h00, 32'h10000537);  // LUI x10, 0x10000 (base addr)
-        write_memory_backdoor(32'h04, 32'h0FF00593);  // LI x11, 0xFF
-        write_memory_backdoor(32'h08, 32'h00B50023);  // SB x11, 0(x10) - byte store
-        write_memory_backdoor(32'h0C, 32'h00B51023);  // SH x11, 0(x10) - halfword store
-        write_memory_backdoor(32'h10, 32'h00B52023);  // SW x11, 0(x10) - word store
-        write_memory_backdoor(32'h14, 32'h00050603);  // LB x12, 0(x10) - byte load
-        write_memory_backdoor(32'h18, 32'h00051683);  // LH x13, 0(x10) - halfword load
-        write_memory_backdoor(32'h1C, 32'h00052703);  // LW x14, 0(x10) - word load
-        write_memory_backdoor(32'h20, 32'h00100073);  // EBREAK
+        // Load test program with various store/load operations (VexRiscv memory base is 0x80000000)
+        write_memory_backdoor(32'h80000000, 32'h10000537);  // LUI x10, 0x10000 (base addr)
+        write_memory_backdoor(32'h80000004, 32'h0FF00593);  // LI x11, 0xFF
+        write_memory_backdoor(32'h80000008, 32'h00B50023);  // SB x11, 0(x10) - byte store
+        write_memory_backdoor(32'h8000000C, 32'h00B51023);  // SH x11, 0(x10) - halfword store
+        write_memory_backdoor(32'h80000010, 32'h00B52023);  // SW x11, 0(x10) - word store
+        write_memory_backdoor(32'h80000014, 32'h00050603);  // LB x12, 0(x10) - byte load
+        write_memory_backdoor(32'h80000018, 32'h00051683);  // LH x13, 0(x10) - halfword load
+        write_memory_backdoor(32'h8000001C, 32'h00052703);  // LW x14, 0(x10) - word load
+        write_memory_backdoor(32'h80000020, 32'h00100073);  // EBREAK
         
         start_cpu();
         

--- a/sim/tests/vexriscv_ex_bypass_test.sv
+++ b/sim/tests/vexriscv_ex_bypass_test.sv
@@ -54,10 +54,10 @@ class vexriscv_ex_bypass_test extends vexriscv_base_test;
         
         reset_cpu();
         
-        // Load test
-        write_memory_backdoor(32'h00, 32'h00500093);  // ADDI x1, x0, 5
-        write_memory_backdoor(32'h04, 32'h00108113);  // ADDI x2, x1, 1
-        write_memory_backdoor(32'h08, 32'h00100073);  // EBREAK
+        // Load test (VexRiscv memory base is 0x80000000)
+        write_memory_backdoor(32'h80000000, 32'h00500093);  // ADDI x1, x0, 5
+        write_memory_backdoor(32'h80000004, 32'h00108113);  // ADDI x2, x1, 1
+        write_memory_backdoor(32'h80000008, 32'h00100073);  // EBREAK
         
         start_cpu();
         

--- a/sim/tests/vexriscv_ibus_fetch_test.sv
+++ b/sim/tests/vexriscv_ibus_fetch_test.sv
@@ -52,11 +52,11 @@ class vexriscv_ibus_fetch_test extends vexriscv_base_test;
         
         reset_cpu();
         
-        // Load test program
+        // Load test program (VexRiscv memory base is 0x80000000)
         for (int i = 0; i < 8; i++) begin
-            write_memory_backdoor(i * 4, 32'h00000013);  // NOPs
+            write_memory_backdoor(32'h80000000 + i * 4, 32'h00000013);  // NOPs
         end
-        write_memory_backdoor(32'h20, 32'h00100073);  // EBREAK at end
+        write_memory_backdoor(32'h80000020, 32'h00100073);  // EBREAK at end
         
         start_cpu();
         

--- a/sim/tests/vexriscv_load_use_stall_test.sv
+++ b/sim/tests/vexriscv_load_use_stall_test.sv
@@ -51,13 +51,14 @@ class vexriscv_load_use_stall_test extends vexriscv_base_test;
         
         reset_cpu();
         
-        // Prepare memory with test value
-        write_memory_backdoor(32'h00, 32'h00000005);  // Data: 5 at address 0
-        
-        // Load test program at offset
-        write_memory_backdoor(32'h100, 32'h00002083);  // LW x1, 0(x0)
-        write_memory_backdoor(32'h104, 32'h00108113);  // ADDI x2, x1, 1
-        write_memory_backdoor(32'h108, 32'h00100073);  // EBREAK
+        // Prepare memory with test value (VexRiscv memory base is 0x80000000)
+        write_memory_backdoor(32'h80001000, 32'h00000005);  // Data: 5 at address 0x80001000
+
+        // Load test program (CPU resets to 0x80000000)
+        write_memory_backdoor(32'h80000000, 32'h80001537);  // LUI x10, 0x80001 (load base addr)
+        write_memory_backdoor(32'h80000004, 32'h00052083);  // LW x1, 0(x10)
+        write_memory_backdoor(32'h80000008, 32'h00108113);  // ADDI x2, x1, 1
+        write_memory_backdoor(32'h8000000C, 32'h00100073);  // EBREAK
         
         start_cpu();
         

--- a/sim/tests/vexriscv_mem_bypass_test.sv
+++ b/sim/tests/vexriscv_mem_bypass_test.sv
@@ -49,10 +49,11 @@ class vexriscv_mem_bypass_test extends vexriscv_base_test;
         
         reset_cpu();
         
-        write_memory_backdoor(32'h00, 32'h00500093);  // ADDI x1, x0, 5
-        write_memory_backdoor(32'h04, 32'h00000013);  // NOP
-        write_memory_backdoor(32'h08, 32'h00108113);  // ADDI x2, x1, 1
-        write_memory_backdoor(32'h0C, 32'h00100073);  // EBREAK
+        // VexRiscv memory base is 0x80000000
+        write_memory_backdoor(32'h80000000, 32'h00500093);  // ADDI x1, x0, 5
+        write_memory_backdoor(32'h80000004, 32'h00000013);  // NOP
+        write_memory_backdoor(32'h80000008, 32'h00108113);  // ADDI x2, x1, 1
+        write_memory_backdoor(32'h8000000C, 32'h00100073);  // EBREAK
         
         start_cpu();
         repeat(20) @(posedge $root.rv32i_tb_top.clk);

--- a/sim/tests/vexriscv_memory_access_test.sv
+++ b/sim/tests/vexriscv_memory_access_test.sv
@@ -80,13 +80,14 @@ class vexriscv_memory_access_test extends vexriscv_base_test;
     
     virtual task load_memory_test_program();
         `uvm_info(get_type_name(), "Loading memory test program...", UVM_MEDIUM)
-        write_memory_backdoor(32'h00, 32'h10000FB7);  // LUI x15, 0x10000
-        write_memory_backdoor(32'h04, 32'h00072023);  // SW x0, 0(x15)
-        write_memory_backdoor(32'h08, 32'h12345537);  // LUI x10, 0x12345
-        write_memory_backdoor(32'h0C, 32'h67850513);  // ADDI x10, x10, 0x678
-        write_memory_backdoor(32'h10, 32'h00A72023);  // SW x10, 0(x15)
-        write_memory_backdoor(32'h14, 32'h00072583);  // LW x11, 0(x15)
-        write_memory_backdoor(32'h18, 32'h00100073);  // EBREAK
+        // VexRiscv memory base is 0x80000000
+        write_memory_backdoor(32'h80000000, 32'h10000FB7);  // LUI x15, 0x10000
+        write_memory_backdoor(32'h80000004, 32'h00072023);  // SW x0, 0(x15)
+        write_memory_backdoor(32'h80000008, 32'h12345537);  // LUI x10, 0x12345
+        write_memory_backdoor(32'h8000000C, 32'h67850513);  // ADDI x10, x10, 0x678
+        write_memory_backdoor(32'h80000010, 32'h00A72023);  // SW x10, 0(x15)
+        write_memory_backdoor(32'h80000014, 32'h00072583);  // LW x11, 0(x15)
+        write_memory_backdoor(32'h80000018, 32'h00100073);  // EBREAK
     endtask
     
 endclass : vexriscv_memory_access_test

--- a/sim/tests/vexriscv_wb_bypass_test.sv
+++ b/sim/tests/vexriscv_wb_bypass_test.sv
@@ -56,11 +56,12 @@ class vexriscv_wb_bypass_test extends vexriscv_base_test;
         
         reset_cpu();
         
-        write_memory_backdoor(32'h00, 32'h00500093);  // ADDI x1, x0, 5
-        write_memory_backdoor(32'h04, 32'h00000013);  // NOP
-        write_memory_backdoor(32'h08, 32'h00000013);  // NOP
-        write_memory_backdoor(32'h0C, 32'h00108113);  // ADDI x2, x1, 1
-        write_memory_backdoor(32'h10, 32'h00100073);  // EBREAK
+        // VexRiscv memory base is 0x80000000
+        write_memory_backdoor(32'h80000000, 32'h00500093);  // ADDI x1, x0, 5
+        write_memory_backdoor(32'h80000004, 32'h00000013);  // NOP
+        write_memory_backdoor(32'h80000008, 32'h00000013);  // NOP
+        write_memory_backdoor(32'h8000000C, 32'h00108113);  // ADDI x2, x1, 1
+        write_memory_backdoor(32'h80000010, 32'h00100073);  // EBREAK
         
         start_cpu();
         


### PR DESCRIPTION
## Summary

- Update test memory addresses from `0x00000000` to `0x80000000` base
- Resolves address range errors in 7 test files

Fixes #13

## Changes

| File | Change |
|------|--------|
| vexriscv_memory_access_test.sv | 7 addresses updated |
| vexriscv_ex_bypass_test.sv | 3 addresses updated |
| vexriscv_ibus_fetch_test.sv | Loop + 1 address updated |
| vexriscv_dbus_access_test.sv | 10 addresses updated |
| vexriscv_load_use_stall_test.sv | Program restructured for 0x80000000 base |
| vexriscv_mem_bypass_test.sv | 4 addresses updated |
| vexriscv_wb_bypass_test.sv | 5 addresses updated |

## Test Results

| Test | Before | After |
|------|--------|-------|
| vexriscv_ibus_fetch_test | 9 errors | ✅ PASS |
| vexriscv_regfile_test | PASS | ✅ PASS |
| Address range errors | 30+ | 0 |

## Note

Some tests still have RTL-related failures (data forwarding, memory access protocol) which are tracked separately.

## Test plan

- [x] Verify address range errors are resolved
- [x] Run vexriscv_ibus_fetch_test - PASS
- [x] Run vexriscv_regfile_test - PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)