### PR TITLE
feat: Add DSIM log cleanup functionality

### DIFF
--- a/scripts/clean_logs.ps1
+++ b/scripts/clean_logs.ps1
@@ -1,0 +1,154 @@
+#==============================================================================
+# DSIM Log Cleanup Script (PowerShell)
+# Usage: .\clean_logs.ps1 [options]
+#
+# Options:
+#   -OlderThanDays N  Delete files older than N days (default: 7)
+#   -DryRun           Show what would be deleted without deleting
+#   -Force            Skip confirmation prompt
+#   -IncludeWaves     Also delete waveform files (.mxd)
+#==============================================================================
+
+param(
+    [int]$OlderThanDays = 7,
+
+    [switch]$DryRun,
+
+    [switch]$Force,
+
+    [switch]$IncludeWaves,
+
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+# Script location
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$Workspace = Split-Path -Parent $ScriptDir
+
+# Directories to clean
+$LogDir = Join-Path $Workspace "sim\exec\logs"
+$WaveDir = Join-Path $Workspace "sim\exec\wave"
+
+# Show help
+if ($Help) {
+    Write-Host @"
+Usage: .\clean_logs.ps1 [options]
+
+Options:
+  -OlderThanDays N  Delete files older than N days (default: 7)
+  -DryRun           Show what would be deleted without deleting
+  -Force            Skip confirmation prompt
+  -IncludeWaves     Also delete waveform files (.mxd)
+  -Help             Show this help
+
+Examples:
+  .\clean_logs.ps1                     # Delete logs older than 7 days
+  .\clean_logs.ps1 -OlderThanDays 3    # Delete logs older than 3 days
+  .\clean_logs.ps1 -DryRun             # Preview without deleting
+  .\clean_logs.ps1 -IncludeWaves       # Also delete old waveforms
+"@
+    exit 0
+}
+
+# Calculate cutoff date
+$cutoffDate = (Get-Date).AddDays(-$OlderThanDays)
+
+Write-Host "============================================================"
+Write-Host "DSIM Log Cleanup"
+Write-Host "============================================================"
+Write-Host "Cutoff date: $($cutoffDate.ToString('yyyy-MM-dd HH:mm:ss'))"
+Write-Host "Delete files older than: $OlderThanDays days"
+Write-Host "Dry run: $(if ($DryRun) { 'Yes' } else { 'No' })"
+Write-Host "Include waves: $(if ($IncludeWaves) { 'Yes' } else { 'No' })"
+Write-Host "============================================================"
+Write-Host ""
+
+# Collect files to delete
+$filesToDelete = @()
+$totalSize = 0
+
+# Log files
+if (Test-Path $LogDir) {
+    $logFiles = Get-ChildItem -Path $LogDir -File -Recurse |
+        Where-Object { $_.LastWriteTime -lt $cutoffDate }
+
+    foreach ($file in $logFiles) {
+        $filesToDelete += $file
+        $totalSize += $file.Length
+    }
+}
+
+# Wave files (optional)
+if ($IncludeWaves -and (Test-Path $WaveDir)) {
+    $waveFiles = Get-ChildItem -Path $WaveDir -File -Recurse |
+        Where-Object { $_.LastWriteTime -lt $cutoffDate }
+
+    foreach ($file in $waveFiles) {
+        $filesToDelete += $file
+        $totalSize += $file.Length
+    }
+}
+
+# Display summary
+Write-Host "Files to delete: $($filesToDelete.Count)"
+Write-Host "Total size: $([math]::Round($totalSize / 1MB, 2)) MB"
+Write-Host ""
+
+if ($filesToDelete.Count -eq 0) {
+    Write-Host "No files to delete."
+    exit 0
+}
+
+# List files
+Write-Host "Files:"
+Write-Host "------------------------------------------------------------"
+foreach ($file in $filesToDelete) {
+    $relPath = $file.FullName.Replace($Workspace, "").TrimStart("\")
+    $size = [math]::Round($file.Length / 1KB, 1)
+    $date = $file.LastWriteTime.ToString("yyyy-MM-dd HH:mm")
+    Write-Host "  [$date] $relPath ($size KB)"
+}
+Write-Host "------------------------------------------------------------"
+Write-Host ""
+
+# Dry run - just show what would be deleted
+if ($DryRun) {
+    Write-Host "[DRY RUN] No files were deleted."
+    exit 0
+}
+
+# Confirm deletion
+if (-not $Force) {
+    $confirm = Read-Host "Delete these files? (y/N)"
+    if ($confirm -ne "y" -and $confirm -ne "Y") {
+        Write-Host "Cancelled."
+        exit 0
+    }
+}
+
+# Delete files
+$deletedCount = 0
+$errorCount = 0
+
+foreach ($file in $filesToDelete) {
+    try {
+        Remove-Item -Path $file.FullName -Force
+        $deletedCount++
+    }
+    catch {
+        Write-Warning "Failed to delete: $($file.FullName)"
+        $errorCount++
+    }
+}
+
+Write-Host ""
+Write-Host "============================================================"
+Write-Host "Cleanup Complete"
+Write-Host "============================================================"
+Write-Host "Deleted: $deletedCount files"
+if ($errorCount -gt 0) {
+    Write-Host "Errors: $errorCount"
+}
+Write-Host "Freed space: $([math]::Round($totalSize / 1MB, 2)) MB"

--- a/scripts/run_regression.ps1
+++ b/scripts/run_regression.ps1
@@ -9,6 +9,7 @@
 #   -Verbosity LVL    UVM verbosity (UVM_LOW, UVM_MEDIUM, UVM_DEBUG)
 #   -StopOnFail       Stop regression on first failure
 #   -ReportFile FILE  Output report file
+#   -CleanupDays N    Auto-delete logs older than N days before run (0=disable)
 #==============================================================================
 
 param(
@@ -24,6 +25,8 @@ param(
     [switch]$StopOnFail,
 
     [string]$ReportFile = "",
+
+    [int]$CleanupDays = 0,
 
     [switch]$Help
 )
@@ -65,6 +68,7 @@ Options:
   -Verbosity LVL    UVM verbosity (UVM_LOW, UVM_MEDIUM, UVM_DEBUG)
   -StopOnFail       Stop on first failure
   -ReportFile FILE  Output report file
+  -CleanupDays N    Auto-delete logs older than N days (0=disable)
   -Help             Show this help
 
 Available Stage 1 tests:
@@ -93,9 +97,55 @@ if ($Tests.Count -gt 0) {
     $TestsToRun = $Stage1Tests
 }
 
+# Directories
+$LogDir = Join-Path $Workspace "sim\exec\logs"
+$WaveDir = Join-Path $Workspace "sim\exec\wave"
+
+# Cleanup old log files
+function Cleanup-OldLogs {
+    param([int]$Days)
+
+    $cutoffDate = (Get-Date).AddDays(-$Days)
+    $deletedCount = 0
+    $totalSize = 0
+
+    # Cleanup log files
+    if (Test-Path $LogDir) {
+        $oldFiles = Get-ChildItem -Path $LogDir -File -Recurse |
+            Where-Object { $_.LastWriteTime -lt $cutoffDate }
+
+        foreach ($file in $oldFiles) {
+            $totalSize += $file.Length
+            Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
+            $deletedCount++
+        }
+    }
+
+    # Cleanup wave files
+    if (Test-Path $WaveDir) {
+        $oldWaves = Get-ChildItem -Path $WaveDir -File -Recurse |
+            Where-Object { $_.LastWriteTime -lt $cutoffDate }
+
+        foreach ($file in $oldWaves) {
+            $totalSize += $file.Length
+            Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
+            $deletedCount++
+        }
+    }
+
+    if ($deletedCount -gt 0) {
+        $sizeMB = [math]::Round($totalSize / 1MB, 2)
+        Write-Host "[Cleanup] Deleted $deletedCount files older than $Days days ($sizeMB MB)"
+    }
+}
+
+# Auto-cleanup if requested
+if ($CleanupDays -gt 0) {
+    Cleanup-OldLogs -Days $CleanupDays
+}
+
 # Setup report file
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
-$LogDir = Join-Path $Workspace "sim\exec\logs"
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 
 if (-not $ReportFile) {

--- a/scripts/run_test.ps1
+++ b/scripts/run_test.ps1
@@ -8,6 +8,7 @@
 #   -Seed N           Random seed (default: 1)
 #   -CompileOnly      Compile only, do not run
 #   -RunOnly          Run only (use existing compiled image)
+#   -CleanupDays N    Auto-delete logs older than N days before run (0=disable)
 #==============================================================================
 
 param(
@@ -24,6 +25,8 @@ param(
     [switch]$CompileOnly,
 
     [switch]$RunOnly,
+
+    [int]$CleanupDays = 0,
 
     [switch]$Help
 )
@@ -45,6 +48,7 @@ Options:
   -Seed N           Random seed (default: 1)
   -CompileOnly      Compile only
   -RunOnly          Run only
+  -CleanupDays N    Auto-delete logs older than N days (0=disable)
   -Help             Show this help
 "@
     exit 0
@@ -91,6 +95,49 @@ function Setup-Environment {
     # Create directories
     New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
     New-Item -ItemType Directory -Force -Path $WaveDir | Out-Null
+
+    # Auto-cleanup old files if requested
+    if ($CleanupDays -gt 0) {
+        Cleanup-OldLogs -Days $CleanupDays
+    }
+}
+
+# Cleanup old log files
+function Cleanup-OldLogs {
+    param([int]$Days)
+
+    $cutoffDate = (Get-Date).AddDays(-$Days)
+    $deletedCount = 0
+    $totalSize = 0
+
+    # Cleanup log files
+    if (Test-Path $LogDir) {
+        $oldFiles = Get-ChildItem -Path $LogDir -File -Recurse |
+            Where-Object { $_.LastWriteTime -lt $cutoffDate }
+
+        foreach ($file in $oldFiles) {
+            $totalSize += $file.Length
+            Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
+            $deletedCount++
+        }
+    }
+
+    # Cleanup wave files
+    if (Test-Path $WaveDir) {
+        $oldWaves = Get-ChildItem -Path $WaveDir -File -Recurse |
+            Where-Object { $_.LastWriteTime -lt $cutoffDate }
+
+        foreach ($file in $oldWaves) {
+            $totalSize += $file.Length
+            Remove-Item -Path $file.FullName -Force -ErrorAction SilentlyContinue
+            $deletedCount++
+        }
+    }
+
+    if ($deletedCount -gt 0) {
+        $sizeMB = [math]::Round($totalSize / 1MB, 2)
+        Write-Host "[Cleanup] Deleted $deletedCount files older than $Days days ($sizeMB MB)"
+    }
 }
 
 # Run DSIM


### PR DESCRIPTION
## Summary

Add automatic and manual cleanup of old simulation logs and waveform files to prevent disk space accumulation.

## Changes

### New Script: `scripts/clean_logs.ps1`

Standalone cleanup script with options:
- `-OlderThanDays N` - Delete files older than N days (default: 7)
- `-DryRun` - Preview without deleting
- `-IncludeWaves` - Also delete `.mxd` waveform files
- `-Force` - Skip confirmation prompt

### Updated: `scripts/run_test.ps1` and `scripts/run_regression.ps1`

New `-CleanupDays N` option for automatic pre-run cleanup:
- When specified, deletes old logs/waves before running tests
- Set to 0 to disable (default)

## Usage Examples

```powershell
# Manual cleanup
.\scripts\clean_logs.ps1 -OlderThanDays 7
.\scripts\clean_logs.ps1 -DryRun              # Preview only
.\scripts\clean_logs.ps1 -IncludeWaves        # Include waveforms

# Auto-cleanup before test
.\scripts\run_test.ps1 test_name -CleanupDays 7

# Auto-cleanup before regression
.\scripts\run_regression.ps1 -Stage 1 -CleanupDays 7
```

## Directories Cleaned

| Directory | Contents |
|-----------|----------|
| `sim/exec/logs/` | `.log`, `_result.json`, `regression_*.txt` |
| `sim/exec/wave/` | `.mxd` waveform files (optional) |

## Test Plan

- [x] `clean_logs.ps1 -DryRun` shows correct files
- [x] `clean_logs.ps1 -Force` deletes files without prompt
- [x] `-CleanupDays` option works in run scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)