### PR TITLE
fix: resolve DBus store-load sequence returning stale data (Issue #18)

### DIFF
--- a/rtl/cpu/vexriscv_hazard_simple.sv
+++ b/rtl/cpu/vexriscv_hazard_simple.sv
@@ -321,8 +321,12 @@ module vexriscv_hazard_simple
             writeBackBuffer_payload_address <= 5'h0;
             writeBackBuffer_payload_data <= 32'h0;
         end else begin
+            // FIX Issue #18: writeBackBuffer_valid must be updated every cycle
+            // to prevent permanent hazard detection when a previous WB write
+            // address matches current decode instruction's source register.
+            // The buffer is valid for exactly one cycle after a WB write.
+            writeBackBuffer_valid <= writeBackWrites_valid;
             if (writeBackWrites_valid) begin
-                writeBackBuffer_valid <= 1'b1;
                 writeBackBuffer_payload_address <= writeBackWrites_payload_address;
                 writeBackBuffer_payload_data <= writeBackWrites_payload_data;
             end

--- a/rtl/cpu/vexriscv_top.sv
+++ b/rtl/cpu/vexriscv_top.sv
@@ -755,7 +755,10 @@ module vexriscv_top
     assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
     assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
     assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
-    assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
+    // FIX Issue #18: Load instructions must use DBus response data, not ALU result
+    assign writeBack_REGFILE_WRITE_DATA = writeBack_MEMORY_ENABLE ?
+                                          writeBack_DBusSimplePlugin_rspFormated :
+                                          memory_to_writeBack_REGFILE_WRITE_DATA;
     assign writeBack_MEMORY_READ_DATA = memory_to_writeBack_MEMORY_READ_DATA;
     
     //==========================================================================

--- a/sim/tests/vexriscv_memory_access_test.sv
+++ b/sim/tests/vexriscv_memory_access_test.sv
@@ -81,12 +81,13 @@ class vexriscv_memory_access_test extends vexriscv_base_test;
     virtual task load_memory_test_program();
         `uvm_info(get_type_name(), "Loading memory test program...", UVM_MEDIUM)
         // VexRiscv memory base is 0x80000000
-        write_memory_backdoor(32'h80000000, 32'h80001FB7);  // LUI x15, 0x80001
-        write_memory_backdoor(32'h80000004, 32'h00072023);  // SW x0, 0(x15)
+        // FIX Issue #18: Corrected instruction encodings (rd=x15, not x14/x31)
+        write_memory_backdoor(32'h80000000, 32'h800017B7);  // LUI x15, 0x80001     (rd=15)
+        write_memory_backdoor(32'h80000004, 32'h0007A023);  // SW x0, 0(x15)        (rs1=15)
         write_memory_backdoor(32'h80000008, 32'h12345537);  // LUI x10, 0x12345
         write_memory_backdoor(32'h8000000C, 32'h67850513);  // ADDI x10, x10, 0x678
-        write_memory_backdoor(32'h80000010, 32'h00A72023);  // SW x10, 0(x15)
-        write_memory_backdoor(32'h80000014, 32'h00072583);  // LW x11, 0(x15)
+        write_memory_backdoor(32'h80000010, 32'h00A7A023);  // SW x10, 0(x15)       (rs1=15)
+        write_memory_backdoor(32'h80000014, 32'h0007A583);  // LW x11, 0(x15)       (rs1=15)
         write_memory_backdoor(32'h80000018, 32'h00100073);  // EBREAK
     endtask
     


### PR DESCRIPTION
## Summary
- Fixed `writeBackBuffer_valid` never being reset, causing permanent hazard detection
- Fixed `writeBack_REGFILE_WRITE_DATA` to use DBus response data for Load instructions
- Corrected instruction encodings in `vexriscv_memory_access_test.sv` (rd/rs1 fields)

## Test plan
- [x] Run `vexriscv_memory_access_test` - **PASS** (x11 = 0x12345678)
- [x] Verify store-load sequence returns correct data
- [ ] Run full regression test suite

## Technical Details

### Root Cause 1: WriteBack Buffer Valid Logic
`writeBackBuffer_valid` was only set when a WriteBack write occurred but never cleared. This caused permanent hazard detection when the buffered address matched decode stage RS1/RS2.

### Root Cause 2: Load Data Path  
`writeBack_REGFILE_WRITE_DATA` always used the ALU result from the memory stage. For Load instructions, it should use `writeBack_DBusSimplePlugin_rspFormated` (the formatted DBus response).

### Root Cause 3: Test Instruction Encoding
The test program had incorrect RISC-V instruction encodings - LUI used rd=x31 instead of rd=x15, and SW/LW used rs1=x14 instead of rs1=x15.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)