### PR TITLE
feat(test): Implement VexRiscv ISA test framework (#50)

### DIFF
--- a/sim/tests/vexriscv_isa_test.sv
+++ b/sim/tests/vexriscv_isa_test.sv
@@ -1,0 +1,55 @@
+`timescale 1ns / 1ps
+
+//==============================================================================
+// VexRiscv ISA Test - Intermediate Base Class
+//==============================================================================
+// Base class for all VexRiscv upstream ISA tests (rv32ui-p-*, rv32ui-v-*, etc.)
+// Inherits hex loading, tohost monitoring, and CPU control from vexriscv_base_test.
+// Derived classes only need to specify hex_file_path.
+//
+// Pass/Fail Protocol:
+//   - tohost = 1 → TEST PASSED
+//   - tohost = other non-zero → TEST FAILED (error code)
+//   - tohost = 0 → test still running (timeout → FAIL)
+//
+// Example usage:
+//   class vexriscv_isa_add_test extends vexriscv_isa_test;
+//       function void build_phase(uvm_phase phase);
+//           hex_file_path = "sim/tests/isa_hex/rv32ui-p-add.hex";
+//           super.build_phase(phase);
+//       endfunction
+//   endclass
+//==============================================================================
+
+class vexriscv_isa_test extends vexriscv_base_test;
+
+    `uvm_component_utils(vexriscv_isa_test)
+
+    function new(string name = "vexriscv_isa_test", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+
+        // ISA tests use tohost protocol (already default=1 in base, explicit for clarity)
+        use_tohost_checking = 1;
+
+        // ISA tests may take longer than unit tests (e.g., rv32ui-p-add takes ~1924 cycles)
+        timeout_cycles = 10000;
+
+        // Auto-start CPU after hex load (already default=1 in base)
+        auto_start_cpu = 1;
+
+        // Note: hex_file_path must be set by derived classes in their build_phase
+        // BEFORE calling super.build_phase()
+    endfunction
+
+    // No run_phase override - use vexriscv_base_test's default sequence:
+    //   1. reset_cpu()
+    //   2. load_hex_file(hex_file_path, translate_addr=1)  // 0x80000000 → 0x00000000
+    //   3. start_cpu()
+    //   4. wait_for_tohost(timeout_cycles)  // Poll 0x00001000 for tohost value
+    //   5. check_test_results()  // tohost=1 → PASS, tohost=other → FAIL with error code
+
+endclass

--- a/sim/uvm/tb/dsim_config.f
+++ b/sim/uvm/tb/dsim_config.f
@@ -112,9 +112,9 @@
 ../../tests/vexriscv_dbus_access_test.sv
 
 # VexRiscv Stage 2 ISA Tests (Issue #50)
-# ../../tests/vexriscv_isa_test.sv  # TODO: File not yet created
-# ../../tests/vexriscv_isa_add_test.sv  # Depends on vexriscv_isa_test
-# ../../tests/vexriscv_isa_addi_test.sv  # Depends on vexriscv_isa_test
+../../tests/vexriscv_isa_test.sv
+../../tests/vexriscv_isa_add_test.sv
+../../tests/vexriscv_isa_addi_test.sv
 
 # Issue #13 Investigation - LED MMIO via UART-AXI path
 ../../tests/vexriscv_led_uart_test.sv


### PR DESCRIPTION
## Summary

Completes Issue #50 Phase C: VexRiscv Stage 2 ISA Test Implementation

### Changes

1. **New File: vexriscv_isa_test.sv** (~45 lines)
   - Intermediate base class extending vexriscv_base_test
   - Provides ISA-specific test configuration
   - Enables reuse of hex loader, tohost monitoring, CPU control

2. **Updated: dsim_config.f**
   - Uncommented vexriscv_isa_test.sv (base class)
   - Uncommented vexriscv_isa_add_test.sv (rv32ui-p-add)
   - Uncommented vexriscv_isa_addi_test.sv (rv32ui-p-addi)

### Test Results

- ✅ vexriscv_isa_add_test: **PASS** (tohost=1 at cycle 1924)
- ✅ vexriscv_isa_addi_test: **PASS** (tohost=1 at cycle 996)
- ✅ vexriscv_isa_smoke regression: **2/2 PASS**
- ✅ Stage 1 backward compatibility: **9/9 PASS** (no regression)

### Implementation Details

**Code Reuse from vexriscv_base_test.sv**:
- Intel HEX loading with address translation (0x80000000 → 0x00000000)
- tohost monitoring and pass/fail detection
- CPU reset/start/halt control
- Memory/register backdoor access

**Minimal New Code**:
- Only ISA-specific settings needed
- test class implementations (add_test, addi_test) are just 24 lines each
- Follows existing UVM test patterns

### Key Achievements

1. **Issue #50 Phase C Complete**: ISA test framework fully implemented
2. **Upstream Compatibility**: Uses upstream VexRiscv ISA test hex files
3. **Extensibility**: New ISA tests can be added with just 13 lines of code
4. **Backward Compatibility**: No impact on existing Stage 1 tests

## Related Issues

Closes #50 (Phase C: ISA Test Execution)
Depends on: #60 (mtvec CSR implementation - now fixed)

🧪 Generated with [Claude Code](https://claude.com/claude-code)