### PR TITLE
feat(test): UART Bridge submodule unit tests (#54)

### DIFF
--- a/scripts/run_test.ps1
+++ b/scripts/run_test.ps1
@@ -65,6 +65,22 @@ $LogDir = Join-Path $Workspace "sim\exec\logs"
 $WaveDir = Join-Path $Workspace "sim\exec\wave"
 $ConfigFile = "dsim_config.f"
 $TopModule = "rv32i_tb_top"
+$IsUvmTest = $true
+
+# Test routing (default: full UVM testbench)
+$unitTestRouting = @{
+    "uart_unit_crc8_test" = @{ ConfigFile = "dsim_uart_unit_config.f"; TopModule = "uart_unit_crc8_tb"; IsUvmTest = $false }
+    "uart_unit_frame_parser_test" = @{ ConfigFile = "dsim_uart_unit_config.f"; TopModule = "uart_unit_frame_parser_tb"; IsUvmTest = $false }
+    "uart_unit_fifo_sync_test" = @{ ConfigFile = "dsim_uart_unit_config.f"; TopModule = "uart_unit_fifo_sync_tb"; IsUvmTest = $false }
+    "uart_unit_uart_rx_test" = @{ ConfigFile = "dsim_uart_unit_config.f"; TopModule = "uart_unit_uart_rx_tb"; IsUvmTest = $false }
+    "uart_unit_uart_tx_test" = @{ ConfigFile = "dsim_uart_unit_config.f"; TopModule = "uart_unit_uart_tx_tb"; IsUvmTest = $false }
+}
+
+if ($unitTestRouting.ContainsKey($TestName)) {
+    $ConfigFile = $unitTestRouting[$TestName].ConfigFile
+    $TopModule = $unitTestRouting[$TestName].TopModule
+    $IsUvmTest = $unitTestRouting[$TestName].IsUvmTest
+}
 
 # Setup environment
 function Setup-Environment {
@@ -201,17 +217,22 @@ function Run-Dsim {
     # Build command arguments
     $dsimExe = Join-Path $DsimHome "bin\dsim.exe"
     $args = @(
-        "-uvm", "1.2",
         "-timescale", "1ns/1ps",
         "-f", $ConfigFile,
         "-top", $TopModule,
-        "+UVM_TESTNAME=$TestName",
-        "+UVM_VERBOSITY=$Verbosity",
         "-sv_seed", $Seed,
-        "-l", $logFile,
-        "+UVM_PHASE_TRACE",
-        "+UVM_OBJECTION_TRACE"
+        "-l", $logFile
     )
+
+    if ($IsUvmTest) {
+        $args += @(
+            "-uvm", "1.2",
+            "+UVM_TESTNAME=$TestName",
+            "+UVM_VERBOSITY=$Verbosity",
+            "+UVM_PHASE_TRACE",
+            "+UVM_OBJECTION_TRACE"
+        )
+    }
 
     if ($Waves) {
         $args += @("-waves", $waveFile)
@@ -255,6 +276,8 @@ function Run-Dsim {
     $uvmErrors = 0
     $uvmFatals = 0
     $testPass = $false
+    $simErrors = 0
+    $simFatals = 0
 
     if (Test-Path $logFile) {
         $logContent = Get-Content $logFile
@@ -267,6 +290,12 @@ function Run-Dsim {
             if ($line -match "^\s*UVM_FATAL\s*:\s*(\d+)") {
                 $uvmFatals = [int]$Matches[1]
             }
+            if ($line -match '^=E:|\$error') {
+                $simErrors++
+            }
+            if ($line -match '^=F:|\$fatal|TEST FAILED') {
+                $simFatals++
+            }
             if ($line -match "TEST PASSED|PASS:\s") {
                 $testPass = $true
             }
@@ -274,8 +303,14 @@ function Run-Dsim {
 
         Write-Host "UVM Errors: $uvmErrors"
         Write-Host "UVM Fatals: $uvmFatals"
+        if ($simErrors -gt 0) {
+            Write-Host "Sim Errors: $simErrors"
+        }
+        if ($simFatals -gt 0) {
+            Write-Host "Sim Fatals: $simFatals"
+        }
 
-        if ($uvmErrors -eq 0 -and $uvmFatals -eq 0 -and $exitCode -eq 0) {
+        if ($uvmErrors -eq 0 -and $uvmFatals -eq 0 -and $simErrors -eq 0 -and $simFatals -eq 0 -and $exitCode -eq 0) {
             Write-Host "Status: PASS"
             $testPass = $true
         } else {

--- a/sim/regression_tests.json
+++ b/sim/regression_tests.json
@@ -46,6 +46,41 @@
         }
       ]
     },
+    "uart_unit": {
+      "description": "UART Bridge submodule unit tests (Crc8, Frame_Parser, fifo_sync, Uart_Rx, Uart_Tx)",
+      "tests": [
+        {
+          "name": "uart_unit_crc8_test",
+          "description": "Crc8_Calculator known vectors, zero data, all-ones data",
+          "timeout": 60,
+          "expected_duration": 5
+        },
+        {
+          "name": "uart_unit_frame_parser_test",
+          "description": "Frame_Parser valid frame, CRC error, truncated-frame timeout",
+          "timeout": 60,
+          "expected_duration": 10
+        },
+        {
+          "name": "uart_unit_fifo_sync_test",
+          "description": "fifo_sync full/empty boundary and simultaneous read/write",
+          "timeout": 60,
+          "expected_duration": 5
+        },
+        {
+          "name": "uart_unit_uart_rx_test",
+          "description": "Uart_Rx valid frame decode, false-start rejection, soft-reset abort",
+          "timeout": 60,
+          "expected_duration": 6
+        },
+        {
+          "name": "uart_unit_uart_tx_test",
+          "description": "Uart_Tx framing, CTS gate behavior, soft-reset abort",
+          "timeout": 60,
+          "expected_duration": 6
+        }
+      ]
+    },
     "vexriscv_smoke": {
       "description": "VexRiscv Stage 1 smoke tests (3 tests, <20s)",
       "tests": [
@@ -620,12 +655,6 @@
     "infrastructure": ["axiuart_reset_test", "axiuart_basic_test"],
     "register_block": ["axiuart_reg_rw_test"],
     "bram_access": ["axiuart_cpu_simple_mem_test"],
-<<<<<<< HEAD
-    "rv32i_cpu": ["rv32i_basic_test", "rv32i_debug_load_test"],
-    "rv32i_debug": ["rv32i_ebreak_simple_test", "rv32i_breakpoint_test"],
-    "rv32i_pipeline": ["rv32i_wb_forward_timing_test", "rv32i_load_use_stall_test"],
-    "vexriscv_isa": ["vexriscv_isa_add_test", "vexriscv_isa_addi_test"],
-=======
     "rv32i_alu_imm": ["rv32i_basic_imm_test", "rv32i_upper_imm_test", "rv32i_imm_logic_test", "rv32i_shift_imm_test"],
     "rv32i_alu_reg": ["rv32i_reg_alu_test", "rv32i_reg_shift_test"],
     "rv32i_memory": ["rv32i_load_simple_test", "rv32i_store_simple_test"],
@@ -637,7 +666,8 @@
     "vexriscv_hazard": ["vexriscv_ex_bypass_test", "vexriscv_mem_bypass_test", "vexriscv_wb_bypass_test", "vexriscv_load_use_stall_test"],
     "vexriscv_bus": ["vexriscv_dbus_access_test"],
     "vexriscv_integration": ["vexriscv_smoke_test", "vexriscv_led_uart_test"],
->>>>>>> 25cfe9ff5d15d694025c10e9f1f6148311820aa2
+    "vexriscv_isa": ["vexriscv_isa_add_test", "vexriscv_isa_addi_test"],
+    "uart_unit": ["uart_unit_crc8_test", "uart_unit_frame_parser_test", "uart_unit_fifo_sync_test", "uart_unit_uart_rx_test", "uart_unit_uart_tx_test"],
     "archived_td4": ["axiuart_cpu_simple_mem_test", "axiuart_cpu_memory_test", "axiuart_cpu_debug_test", "axiuart_cpu_mmio_led_test", "axiuart_cpu_br_test"]
   },
   "stage_mapping": {

--- a/sim/tests/uart_unit_crc8_tb.sv
+++ b/sim/tests/uart_unit_crc8_tb.sv
@@ -1,0 +1,100 @@
+`timescale 1ns / 1ps
+
+module uart_unit_crc8_tb;
+    logic clk;
+    logic rst;
+    logic crc_enable;
+    logic [7:0] data_in;
+    logic crc_reset;
+    logic [7:0] crc_out;
+    logic [7:0] crc_final;
+
+    int fail_count;
+
+    Crc8_Calculator dut (
+        .clk(clk),
+        .rst(rst),
+        .crc_enable(crc_enable),
+        .data_in(data_in),
+        .crc_reset(crc_reset),
+        .crc_out(crc_out),
+        .crc_final(crc_final)
+    );
+
+    initial begin
+        clk = 1'b0;
+        forever #5 clk = ~clk;
+    end
+
+    task automatic apply_reset;
+        begin
+            rst = 1'b1;
+            crc_enable = 1'b0;
+            crc_reset = 1'b0;
+            data_in = 8'h00;
+            repeat (2) @(posedge clk);
+            rst = 1'b0;
+            @(posedge clk);
+        end
+    endtask
+
+    task automatic pulse_crc_reset;
+        begin
+            crc_reset = 1'b1;
+            @(posedge clk);
+            crc_reset = 1'b0;
+            @(posedge clk);
+        end
+    endtask
+
+    task automatic push_byte(input logic [7:0] value);
+        begin
+            data_in = value;
+            crc_enable = 1'b1;
+            @(posedge clk);
+            crc_enable = 1'b0;
+            @(posedge clk);
+        end
+    endtask
+
+    task automatic check_crc(input logic [7:0] expected, input string label);
+        begin
+            if (crc_out !== expected || crc_final !== expected) begin
+                $error("[CRC8_UNIT] %s failed: expected=0x%02h got_out=0x%02h got_final=0x%02h",
+                       label, expected, crc_out, crc_final);
+                fail_count++;
+            end
+        end
+    endtask
+
+    initial begin
+        fail_count = 0;
+        apply_reset();
+
+        // Known pattern: 12 34 56 78 -> CRC=1C
+        pulse_crc_reset();
+        push_byte(8'h12);
+        push_byte(8'h34);
+        push_byte(8'h56);
+        push_byte(8'h78);
+        check_crc(8'h1C, "Known vector 12 34 56 78");
+
+        // Zero data input: 00 -> CRC=00
+        pulse_crc_reset();
+        push_byte(8'h00);
+        check_crc(8'h00, "Zero data vector 00");
+
+        // All-ones data input: FF -> CRC=F3
+        pulse_crc_reset();
+        push_byte(8'hFF);
+        check_crc(8'hF3, "All-ones vector FF");
+
+        if (fail_count == 0) begin
+            $display("[CRC8_UNIT] TEST PASSED");
+            $finish;
+        end else begin
+            $fatal(1, "[CRC8_UNIT] TEST FAILED (fail_count=%0d)", fail_count);
+        end
+    end
+
+endmodule

--- a/sim/tests/uart_unit_fifo_sync_tb.sv
+++ b/sim/tests/uart_unit_fifo_sync_tb.sv
@@ -1,0 +1,139 @@
+`timescale 1ns / 1ps
+
+module uart_unit_fifo_sync_tb;
+    localparam int FIFO_DEPTH = 4;
+
+    logic clk;
+    logic rst;
+    logic wr_en;
+    logic [7:0] wr_data;
+    logic full;
+    logic almost_full;
+    logic rd_en;
+    logic [7:0] rd_data;
+    logic empty;
+    logic almost_empty;
+    logic [2:0] count;
+
+    int fail_count;
+
+    fifo_sync #(
+        .DATA_WIDTH(8),
+        .FIFO_DEPTH(FIFO_DEPTH)
+    ) dut (
+        .clk(clk),
+        .rst(rst),
+        .wr_en(wr_en),
+        .wr_data(wr_data),
+        .full(full),
+        .almost_full(almost_full),
+        .rd_en(rd_en),
+        .rd_data(rd_data),
+        .empty(empty),
+        .almost_empty(almost_empty),
+        .count(count)
+    );
+
+    initial begin
+        clk = 1'b0;
+        forever #5 clk = ~clk;
+    end
+
+    task automatic apply_reset;
+        begin
+            rst = 1'b1;
+            wr_en = 1'b0;
+            rd_en = 1'b0;
+            wr_data = 8'h00;
+            repeat (2) @(posedge clk);
+            rst = 1'b0;
+            @(posedge clk);
+        end
+    endtask
+
+    task automatic write_byte(input logic [7:0] value);
+        begin
+            wr_data = value;
+            wr_en = 1'b1;
+            @(posedge clk);
+            wr_en = 1'b0;
+            @(posedge clk);
+        end
+    endtask
+
+    task automatic read_byte(output logic [7:0] value);
+        begin
+            value = rd_data;
+            rd_en = 1'b1;
+            @(posedge clk);
+            rd_en = 1'b0;
+            @(posedge clk);
+        end
+    endtask
+
+    task automatic check(input logic condition, input string label);
+        begin
+            if (!condition) begin
+                $error("[FIFO_UNIT] check failed: %s", label);
+                fail_count++;
+            end
+        end
+    endtask
+
+    initial begin
+        logic [7:0] v;
+
+        fail_count = 0;
+        apply_reset();
+
+        // Empty condition after reset
+        check(empty && !full && (count == 0), "reset empty/full/count");
+
+        // Fill exactly to depth (boundary)
+        write_byte(8'h11);
+        write_byte(8'h22);
+        write_byte(8'h33);
+        write_byte(8'h44);
+        check(full && !empty && (count == FIFO_DEPTH), "full at exact depth");
+        check(almost_full, "almost_full asserted near/full");
+
+        // Overflow attempt should not change count
+        write_byte(8'h55);
+        check(full && (count == FIFO_DEPTH), "overflow write blocked");
+
+        // Read all data and verify order
+        read_byte(v); check(v == 8'h11, "read order item0");
+        read_byte(v); check(v == 8'h22, "read order item1");
+        read_byte(v); check(v == 8'h33, "read order item2");
+        read_byte(v); check(v == 8'h44, "read order item3");
+        check(empty && !full && (count == 0), "empty after draining");
+
+        // Simultaneous read/write keeps count and updates queue correctly
+        write_byte(8'hA1);
+        write_byte(8'hB2);
+        check(count == 2, "prefill count for simultaneous rw");
+
+        wr_data = 8'hC3;
+        wr_en = 1'b1;
+        rd_en = 1'b1;
+        v = rd_data;
+        @(posedge clk);
+        wr_en = 1'b0;
+        rd_en = 1'b0;
+        @(posedge clk);
+
+        check(v == 8'hA1, "simultaneous rw read returns old head");
+        check(count == 2, "simultaneous rw count unchanged");
+
+        read_byte(v); check(v == 8'hB2, "simultaneous rw remaining item0");
+        read_byte(v); check(v == 8'hC3, "simultaneous rw remaining item1");
+
+        if (fail_count == 0) begin
+            $display("[FIFO_UNIT] TEST PASSED");
+            $finish;
+        end else begin
+            $fatal(1, "[FIFO_UNIT] TEST FAILED (fail_count=%0d)", fail_count);
+        end
+    end
+
+endmodule

--- a/sim/tests/uart_unit_frame_parser_tb.sv
+++ b/sim/tests/uart_unit_frame_parser_tb.sv
@@ -1,0 +1,242 @@
+`timescale 1ns / 1ps
+
+module uart_unit_frame_parser_tb;
+    localparam logic [7:0] SOF = 8'hA5;
+    localparam logic [7:0] STATUS_OK = 8'h00;
+    localparam logic [7:0] STATUS_CRC_ERR = 8'h01;
+    localparam logic [7:0] STATUS_TIMEOUT = 8'h04;
+    localparam logic [7:0] TEST_CMD = 8'h40;  // WRITE, increment, byte-size, len=1 byte
+
+    logic clk;
+    logic rst;
+
+    logic [7:0] rx_fifo_data;
+    logic rx_fifo_empty;
+    logic rx_fifo_rd_en;
+    logic [15:0] baud_divisor;
+
+    logic [7:0] cmd;
+    logic [31:0] addr;
+    logic [7:0] data_out [0:63];
+    logic [6:0] data_count;
+    logic frame_valid;
+    logic [7:0] error_status;
+    logic frame_error;
+    logic frame_consumed;
+    logic parser_busy;
+    logic soft_reset_request;
+    logic [7:0] debug_cmd_in;
+    logic [7:0] debug_cmd_decoded;
+    logic [7:0] debug_status_out;
+    logic [7:0] debug_crc_in;
+    logic [7:0] debug_crc_calc;
+    logic debug_crc_error;
+    logic [3:0] debug_state;
+    logic [7:0] debug_error_cause;
+
+    byte unsigned rx_stream[$];
+    int fail_count;
+
+    Frame_Parser #(
+        .CLK_FREQ_HZ(1000),
+        .BAUD_RATE(100),
+        .TIMEOUT_BYTE_TIMES(1),
+        .ENABLE_TIMEOUT(1'b1),
+        .ENABLE_ASSERTIONS(1'b0)
+    ) dut (
+        .clk(clk),
+        .rst(rst),
+        .rx_fifo_data(rx_fifo_data),
+        .rx_fifo_empty(rx_fifo_empty),
+        .rx_fifo_rd_en(rx_fifo_rd_en),
+        .baud_divisor(baud_divisor),
+        .cmd(cmd),
+        .addr(addr),
+        .data_out(data_out),
+        .data_count(data_count),
+        .frame_valid(frame_valid),
+        .error_status(error_status),
+        .frame_error(frame_error),
+        .frame_consumed(frame_consumed),
+        .parser_busy(parser_busy),
+        .soft_reset_request(soft_reset_request),
+        .debug_cmd_in(debug_cmd_in),
+        .debug_cmd_decoded(debug_cmd_decoded),
+        .debug_status_out(debug_status_out),
+        .debug_crc_in(debug_crc_in),
+        .debug_crc_calc(debug_crc_calc),
+        .debug_crc_error(debug_crc_error),
+        .debug_state(debug_state),
+        .debug_error_cause(debug_error_cause)
+    );
+
+    initial begin
+        clk = 1'b0;
+        forever #5 clk = ~clk;
+    end
+
+    always_comb begin
+        rx_fifo_empty = (rx_stream.size() == 0);
+        rx_fifo_data = rx_fifo_empty ? 8'h00 : rx_stream[0];
+    end
+
+    always_ff @(posedge clk) begin
+        if (!rst && rx_fifo_rd_en && !rx_fifo_empty) begin
+            void'(rx_stream.pop_front());
+        end
+    end
+
+    function automatic logic [7:0] calc_crc8_byte(input logic [7:0] current_crc, input logic [7:0] data_byte);
+        logic [7:0] crc_temp;
+        begin
+            crc_temp = current_crc ^ data_byte;
+            repeat (8) begin
+                if (crc_temp[7]) begin
+                    crc_temp = (crc_temp << 1) ^ 8'h07;
+                end else begin
+                    crc_temp = crc_temp << 1;
+                end
+            end
+            return crc_temp;
+        end
+    endfunction
+
+    function automatic logic [7:0] calc_crc_payload(input byte unsigned payload[$]);
+        logic [7:0] crc;
+        begin
+            crc = 8'h00;
+            foreach (payload[i]) begin
+                crc = calc_crc8_byte(crc, payload[i]);
+            end
+            return crc;
+        end
+    endfunction
+
+    task automatic enqueue_frame(input byte unsigned payload[$], input logic [7:0] crc_value);
+        begin
+            rx_stream.push_back(SOF);
+            foreach (payload[i]) begin
+                rx_stream.push_back(payload[i]);
+            end
+            rx_stream.push_back(crc_value);
+        end
+    endtask
+
+    task automatic consume_frame;
+        begin
+            frame_consumed = 1'b1;
+            @(posedge clk);
+            frame_consumed = 1'b0;
+            repeat (3) @(posedge clk);
+        end
+    endtask
+
+    task automatic wait_for_terminal_state(input int max_cycles, input string label);
+        begin
+            for (int i = 0; i < max_cycles; i++) begin
+                @(posedge clk);
+                if (frame_valid || frame_error) begin
+                    return;
+                end
+            end
+            $error("[FRAME_PARSER_UNIT] %s timeout waiting for frame_valid/frame_error", label);
+            fail_count++;
+        end
+    endtask
+
+    initial begin
+        byte unsigned payload[$];
+        logic [7:0] good_crc;
+        logic [7:0] bad_crc;
+
+        fail_count = 0;
+        frame_consumed = 1'b0;
+        baud_divisor = 16'd16;
+        rst = 1'b1;
+        repeat (3) @(posedge clk);
+        rst = 1'b0;
+        repeat (2) @(posedge clk);
+
+        // Case 1: valid frame parse
+        payload.delete();
+        payload.push_back(TEST_CMD);
+        payload.push_back(8'h00);
+        payload.push_back(8'h10);
+        payload.push_back(8'h00);
+        payload.push_back(8'h00);
+        payload.push_back(8'h5A);
+        good_crc = calc_crc_payload(payload);
+        enqueue_frame(payload, good_crc);
+
+        wait_for_terminal_state(300, "valid frame");
+        if (!frame_valid) begin
+            $error("[FRAME_PARSER_UNIT] valid frame: frame_valid not asserted");
+            fail_count++;
+        end
+        if (frame_error) begin
+            $error("[FRAME_PARSER_UNIT] valid frame: unexpected frame_error");
+            fail_count++;
+        end
+        if (cmd !== TEST_CMD || addr !== 32'h0000_1000 || data_count !== 7'd1 || data_out[0] !== 8'h5A) begin
+            $error("[FRAME_PARSER_UNIT] valid frame payload mismatch cmd=%02h addr=%08h count=%0d data0=%02h",
+                   cmd, addr, data_count, data_out[0]);
+            fail_count++;
+        end
+        if (error_status !== STATUS_OK) begin
+            $error("[FRAME_PARSER_UNIT] valid frame status mismatch: %02h", error_status);
+            fail_count++;
+        end
+        consume_frame();
+
+        // Case 2: bad CRC rejection
+        payload.delete();
+        payload.push_back(TEST_CMD);
+        payload.push_back(8'h04);
+        payload.push_back(8'h10);
+        payload.push_back(8'h00);
+        payload.push_back(8'h00);
+        payload.push_back(8'hA6);
+        good_crc = calc_crc_payload(payload);
+        bad_crc = good_crc ^ 8'hFF;
+        enqueue_frame(payload, bad_crc);
+
+        wait_for_terminal_state(300, "bad crc frame");
+        if (!frame_error) begin
+            $error("[FRAME_PARSER_UNIT] bad CRC frame: frame_error not asserted");
+            fail_count++;
+        end
+        if (frame_valid) begin
+            $error("[FRAME_PARSER_UNIT] bad CRC frame: frame_valid should be 0");
+            fail_count++;
+        end
+        if (error_status !== STATUS_CRC_ERR) begin
+            $error("[FRAME_PARSER_UNIT] bad CRC frame: expected STATUS_CRC_ERR got=%02h", error_status);
+            fail_count++;
+        end
+        consume_frame();
+
+        // Case 3: truncated frame timeout
+        rx_stream.delete();
+        rx_stream.push_back(SOF);
+        rx_stream.push_back(TEST_CMD);
+
+        wait_for_terminal_state(300, "truncated frame timeout");
+        if (!frame_error) begin
+            $error("[FRAME_PARSER_UNIT] truncated frame: frame_error not asserted");
+            fail_count++;
+        end
+        if (frame_valid) begin
+            $error("[FRAME_PARSER_UNIT] truncated frame: frame_valid should be 0");
+            fail_count++;
+        end
+        consume_frame();
+
+        if (fail_count == 0) begin
+            $display("[FRAME_PARSER_UNIT] TEST PASSED");
+            $finish;
+        end else begin
+            $fatal(1, "[FRAME_PARSER_UNIT] TEST FAILED (fail_count=%0d)", fail_count);
+        end
+    end
+
+endmodule

--- a/sim/tests/uart_unit_uart_rx_tb.sv
+++ b/sim/tests/uart_unit_uart_rx_tb.sv
@@ -1,0 +1,169 @@
+`timescale 1ns / 1ps
+
+module uart_unit_uart_rx_tb;
+    localparam int OVERSAMPLE = 16;
+    localparam int BAUD_DIVISOR = 16;
+
+    logic clk;
+    logic rst;
+    logic soft_reset_request;
+    logic uart_rx;
+    logic [15:0] baud_divisor;
+    logic [7:0] rx_data;
+    logic rx_valid;
+    logic rx_error;
+    logic rx_busy;
+
+    logic [7:0] tx_data;
+    logic tx_start;
+    logic tx_busy;
+    logic tx_done;
+    logic tx_uart;
+    logic uart_cts_n;
+    logic manual_mode;
+    logic manual_uart;
+
+    int fail_count;
+
+    Uart_Rx #(
+        .CLK_FREQ_HZ(16_000),
+        .BAUD_RATE(1_000),
+        .OVERSAMPLE(OVERSAMPLE)
+    ) dut (
+        .clk(clk),
+        .rst(rst),
+        .soft_reset_request(soft_reset_request),
+        .uart_rx(uart_rx),
+        .baud_divisor(baud_divisor),
+        .rx_data(rx_data),
+        .rx_valid(rx_valid),
+        .rx_error(rx_error),
+        .rx_busy(rx_busy)
+    );
+
+    Uart_Tx #(
+        .CLK_FREQ_HZ(16_000),
+        .BAUD_RATE(1_000),
+        .OVERSAMPLE(OVERSAMPLE)
+    ) stim_tx (
+        .clk(clk),
+        .rst(rst),
+        .soft_reset_request(1'b0),
+        .tx_data(tx_data),
+        .tx_start(tx_start),
+        .uart_cts_n(uart_cts_n),
+        .baud_divisor(baud_divisor),
+        .uart_tx(tx_uart),
+        .tx_busy(tx_busy),
+        .tx_done(tx_done)
+    );
+
+    initial begin
+        clk = 1'b0;
+        forever #5 clk = ~clk;
+    end
+
+    task automatic apply_reset;
+        begin
+            rst = 1'b1;
+            soft_reset_request = 1'b0;
+            baud_divisor = BAUD_DIVISOR;
+            tx_data = 8'h00;
+            tx_start = 1'b0;
+            uart_cts_n = 1'b0;
+            manual_mode = 1'b0;
+            manual_uart = 1'b1;
+            repeat (4) @(posedge clk);
+            rst = 1'b0;
+            repeat (4) @(posedge clk);
+        end
+    endtask
+
+    task automatic start_tx_byte(input logic [7:0] value);
+        begin
+            tx_data = value;
+            tx_start = 1'b1;
+            @(posedge clk);
+            tx_start = 1'b0;
+        end
+    endtask
+
+    task automatic wait_for_rx_valid(input int max_cycles, input string label, output bit seen);
+        begin
+            seen = 1'b0;
+            if (rx_valid) begin
+                seen = 1'b1;
+                return;
+            end
+            for (int i = 0; i < max_cycles; i++) begin
+                @(posedge clk);
+                if (rx_valid) begin
+                    seen = 1'b1;
+                    return;
+                end
+            end
+            $error("[UART_RX_UNIT] %s: timeout waiting for rx_valid", label);
+            fail_count++;
+        end
+    endtask
+
+    task automatic check(input logic cond, input string label);
+        begin
+            if (!cond) begin
+                $error("[UART_RX_UNIT] check failed: %s", label);
+                fail_count++;
+            end
+        end
+    endtask
+
+    always_comb begin
+        uart_rx = manual_mode ? manual_uart : tx_uart;
+    end
+
+    initial begin
+        bit seen;
+
+        fail_count = 0;
+        apply_reset();
+
+        // Case 1: valid frame decode
+        manual_mode = 1'b0;
+        start_tx_byte(8'hA5);
+        wait_for_rx_valid(800, "valid frame", seen);
+        if (seen) begin
+            check(rx_data == 8'hA5, "valid frame data = 0xA5");
+            check(rx_error == 1'b0, "valid frame rx_error=0");
+            @(posedge clk);
+            check(!rx_valid, "rx_valid single-cycle pulse");
+        end
+
+        // Case 2: false-start rejection (short low glitch)
+        manual_mode = 1'b1;
+        manual_uart = 1'b1;
+        repeat (6) @(posedge clk);
+        manual_uart = 1'b0;
+        repeat (2) @(posedge clk);
+        manual_uart = 1'b1;
+        repeat (120) @(posedge clk);
+        check(!rx_valid, "false start does not produce rx_valid");
+
+        // Case 3: soft reset abort mid-frame
+        manual_mode = 1'b0;
+        start_tx_byte(8'h3C);
+        repeat (50) @(posedge clk);
+        soft_reset_request = 1'b1;
+        @(posedge clk);
+        soft_reset_request = 1'b0;
+        wait (tx_done == 1'b1);
+        repeat (80) @(posedge clk);
+        check(!rx_valid, "soft reset abort prevents completion");
+
+        if (fail_count == 0) begin
+            $display("[UART_RX_UNIT] TEST PASSED");
+            $finish;
+        end else begin
+            $fatal(1, "[UART_RX_UNIT] TEST FAILED (fail_count=%0d)", fail_count);
+        end
+    end
+
+endmodule

--- a/sim/tests/uart_unit_uart_tx_tb.sv
+++ b/sim/tests/uart_unit_uart_tx_tb.sv
@@ -1,0 +1,163 @@
+`timescale 1ns / 1ps
+
+module uart_unit_uart_tx_tb;
+    localparam int BAUD_DIVISOR = 8;
+
+    logic clk;
+    logic rst;
+    logic soft_reset_request;
+    logic [7:0] tx_data;
+    logic tx_start;
+    logic uart_cts_n;
+    logic [15:0] baud_divisor;
+    logic uart_tx;
+    logic tx_busy;
+    logic tx_done;
+
+    int fail_count;
+
+    Uart_Tx #(
+        .CLK_FREQ_HZ(8_000),
+        .BAUD_RATE(1_000),
+        .OVERSAMPLE(16)
+    ) dut (
+        .clk(clk),
+        .rst(rst),
+        .soft_reset_request(soft_reset_request),
+        .tx_data(tx_data),
+        .tx_start(tx_start),
+        .uart_cts_n(uart_cts_n),
+        .baud_divisor(baud_divisor),
+        .uart_tx(uart_tx),
+        .tx_busy(tx_busy),
+        .tx_done(tx_done)
+    );
+
+    initial begin
+        clk = 1'b0;
+        forever #5 clk = ~clk;
+    end
+
+    task automatic apply_reset;
+        begin
+            rst = 1'b1;
+            soft_reset_request = 1'b0;
+            tx_data = 8'h00;
+            tx_start = 1'b0;
+            uart_cts_n = 1'b0;
+            baud_divisor = BAUD_DIVISOR;
+            repeat (4) @(posedge clk);
+            rst = 1'b0;
+            repeat (4) @(posedge clk);
+        end
+    endtask
+
+    task automatic start_tx(input logic [7:0] value);
+        begin
+            tx_data = value;
+            tx_start = 1'b1;
+            @(posedge clk);
+            tx_start = 1'b0;
+        end
+    endtask
+
+    task automatic wait_until_busy(input int max_cycles, input string label, output bit seen);
+        begin
+            seen = 1'b0;
+            for (int i = 0; i < max_cycles; i++) begin
+                @(posedge clk);
+                if (tx_busy) begin
+                    seen = 1'b1;
+                    return;
+                end
+            end
+            $error("[UART_TX_UNIT] %s: timeout waiting for tx_busy", label);
+            fail_count++;
+        end
+    endtask
+
+    task automatic wait_until_done(input int max_cycles, input string label, output bit seen);
+        begin
+            seen = 1'b0;
+            for (int i = 0; i < max_cycles; i++) begin
+                @(posedge clk);
+                if (tx_done) begin
+                    seen = 1'b1;
+                    return;
+                end
+            end
+            $error("[UART_TX_UNIT] %s: timeout waiting for tx_done", label);
+            fail_count++;
+        end
+    endtask
+
+    task automatic check(input logic cond, input string label);
+        begin
+            if (!cond) begin
+                $error("[UART_TX_UNIT] check failed: %s", label);
+                fail_count++;
+            end
+        end
+    endtask
+
+    initial begin
+        bit seen;
+        logic [7:0] test_byte;
+
+        fail_count = 0;
+        apply_reset();
+
+        // Case 1: normal transmit framing + tx_done pulse
+        test_byte = 8'h96;
+        start_tx(test_byte);
+        wait_until_busy(40, "normal tx start", seen);
+
+        repeat (BAUD_DIVISOR/2) @(posedge clk);
+        check(uart_tx == 1'b0, "start bit is low");
+
+        for (int i = 0; i < 8; i++) begin
+            repeat (BAUD_DIVISOR) @(posedge clk);
+            check(uart_tx == test_byte[i], $sformatf("data bit[%0d] matches", i));
+        end
+
+        repeat (BAUD_DIVISOR) @(posedge clk);
+        check(uart_tx == 1'b1, "stop bit is high");
+
+        wait_until_done(40, "normal tx done", seen);
+        if (seen) begin
+            @(posedge clk);
+            check(!tx_done, "tx_done single-cycle pulse");
+            check(!tx_busy, "tx not busy after done");
+            check(uart_tx, "tx line idle high after done");
+        end
+
+        // Case 2: CTS gate blocks start when deasserted (active low)
+        uart_cts_n = 1'b1;
+        start_tx(8'h55);
+        repeat (BAUD_DIVISOR*3) @(posedge clk);
+        check(!tx_busy, "tx blocked when cts_n=1");
+        check(uart_tx, "tx line stays idle when blocked");
+        uart_cts_n = 1'b0;
+
+        // Case 3: soft reset abort while busy
+        start_tx(8'h3C);
+        wait_until_busy(40, "soft reset case start", seen);
+        if (seen) begin
+            repeat (BAUD_DIVISOR*2) @(posedge clk);
+            soft_reset_request = 1'b1;
+            @(posedge clk);
+            soft_reset_request = 1'b0;
+            repeat (4) @(posedge clk);
+            check(!tx_busy, "soft reset clears busy");
+            check(uart_tx, "soft reset returns line to idle high");
+        end
+
+        if (fail_count == 0) begin
+            $display("[UART_TX_UNIT] TEST PASSED");
+            $finish;
+        end else begin
+            $fatal(1, "[UART_TX_UNIT] TEST FAILED (fail_count=%0d)", fail_count);
+        end
+    end
+
+endmodule

--- a/sim/uvm/tb/dsim_uart_unit_config.f
+++ b/sim/uvm/tb/dsim_uart_unit_config.f
@@ -1,0 +1,18 @@
+# DSIM file list for UART Bridge unit tests (Issue #54)
+
++incdir+../../../rtl/uart_axi4_bridge
++incdir+../../tests
+
+# RTL under test
+../../../rtl/uart_axi4_bridge/Crc8_Calculator.sv
+../../../rtl/uart_axi4_bridge/Frame_Parser.sv
+../../../rtl/uart_axi4_bridge/fifo_sync.sv
+../../../rtl/uart_axi4_bridge/Uart_Rx.sv
+../../../rtl/uart_axi4_bridge/Uart_Tx.sv
+
+# Unit testbenches
+../../tests/uart_unit_crc8_tb.sv
+../../tests/uart_unit_frame_parser_tb.sv
+../../tests/uart_unit_fifo_sync_tb.sv
+../../tests/uart_unit_uart_rx_tb.sv
+../../tests/uart_unit_uart_tx_tb.sv


### PR DESCRIPTION
## Summary
- add standalone unit tests for Crc8_Calculator, Frame_Parser, fifo_sync, Uart_Rx, and Uart_Tx
- add UART unit DSIM filelist and run routing for non-UVM unit tops
- register uart_unit regression suite entries and categories

## Validation
- powershell -ExecutionPolicy Bypass -File .\scripts\run_regression.ps1 -Suite uart_unit -Verbosity UVM_LOW
- Result: 5 passed, 0 failed

Closes #54